### PR TITLE
Avoid accidentally changing to the home directory before ct_run

### DIFF
--- a/ct.bzl
+++ b/ct.bzl
@@ -78,7 +78,9 @@ fi
 
 {test_env}
 
-cd {package}
+if [ -n "{package}" ]; then
+    cd {package}
+fi
 
 FILTER=${{FOCUS:-{filter_tests_args}}}
 

--- a/ct_sharded.bzl
+++ b/ct_sharded.bzl
@@ -79,7 +79,9 @@ else
     fi
 fi
 
-cd {package}
+if [ -n "{package}" ]; then
+    cd {package}
+fi
 
 set -x
 {erlang_home}/bin/ct_run \\


### PR DESCRIPTION
when testing a target in the root package