### PR TITLE
Allow generated files in erlang_lib/test_erlang_lib extra_priv

### DIFF
--- a/bazel_erlang_lib.bzl
+++ b/bazel_erlang_lib.bzl
@@ -358,7 +358,7 @@ def erlang_lib(
         hdrs = native.glob(["include/**/*.hrl"]),
         app = app,
         beam = all_beam,
-        priv = native.glob(["priv/**/*"] + extra_priv),
+        priv = native.glob(["priv/**/*"]) + extra_priv,
         deps = deps + runtime_deps,
         visibility = ["//visibility:public"],
     )
@@ -423,7 +423,7 @@ def test_erlang_lib(
         hdrs = native.glob(["include/**/*.hrl"]),
         app = app,
         beam = all_beam,
-        priv = native.glob(["priv/**/*"] + extra_priv),
+        priv = native.glob(["priv/**/*"]) + extra_priv,
         deps = deps + runtime_deps,
         visibility = ["//visibility:public"],
         testonly = True,


### PR DESCRIPTION
extra_priv is no longer part of a glob, which allow us to pass files that will be generated