### PR TITLE
New approach to handling deps in tests

### DIFF
--- a/bazel_erlang_lib.bzl
+++ b/bazel_erlang_lib.bzl
@@ -1,12 +1,12 @@
 load(":erlang_home.bzl", "ErlangHomeProvider", "ErlangVersionProvider")
 
 ErlangLibInfo = provider(
-    doc = "Compiled Erlang sources",
+    doc = "Compiled Erlang Library/Application",
     fields = {
         "lib_name": "Name of the erlang lib",
         "erlang_version": "The erlang version used to produce the beam files",
         "include": "Public header files",
-        "beam": "Compiled bytecode",
+        "beam": "Compiled bytecode (.beam) files, or a single ebin directory",
         "priv": "Additional files",
         "deps": "Runtime dependencies of the compiled sources",
     },

--- a/ct_sharded.bzl
+++ b/ct_sharded.bzl
@@ -10,22 +10,15 @@ load(
     "flat_deps",
     "path_join",
 )
-load(":ct.bzl", "code_paths", "sanitize_sname", "short_dirname", _assert_suites = "assert_suites")
-
-ERL_LIBS_DIR = "deps"
-
-def additional_file_dest_relative_path(dep_label, f):
-    if dep_label.workspace_root != "":
-        if dep_label.package != "":
-            rel_base = path_join(dep_label.workspace_root, dep_label.package)
-        else:
-            rel_base = dep_label.workspace_root
-    else:
-        rel_base = dep_label.package
-    if rel_base != "":
-        return f.short_path.replace(rel_base + "/", "")
-    else:
-        return f.short_path
+load(
+    ":ct.bzl",
+    "ERL_LIBS_DIR",
+    "additional_file_dest_relative_path",
+    "code_paths",
+    "sanitize_sname",
+    "short_dirname",
+    _assert_suites = "assert_suites",
+)
 
 def _impl(ctx):
     erlang_version = ctx.attr._erlang_version[ErlangVersionProvider].version


### PR DESCRIPTION
The existing approach to making compiled dependencies to tests (ultimately to `ct_run`) was with `-pa ...` args.

As it turns out, providing deps this way does not allow correct loading of native extensions.

This PR changes the approach for tests, constructing a `deps` dir for each test with appropriately structured subdirs, and setting `ERL_LIBS` to that directory for the test run.

This may break some usages that make certain assumptions about paths, but otherwise should behave equivalently.